### PR TITLE
Add caption and storyboard generation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -156,6 +156,10 @@ The solution leverages several Twelve Labs API capabilities:
 - `generate.summarize`: For generating video summaries
 - `generate.text`: For creative assessment and semantic analysis
 - `search.vector`: For finding similar videos
+- `generate.caption` (optional): For producing a short caption of the video
+- `generate.storyboard` (optional): For retrieving representative storyboard frames
+
+When these optional endpoints are available, the Streamlit app displays the generated caption and storyboard images inside the **Twelve Labs API Analysis** section after a video is processed.
 
 
 

--- a/backend/analyzer.py
+++ b/backend/analyzer.py
@@ -171,10 +171,36 @@ class VideoAnalyzer:
             for keyword in creative_keywords:
                 if keyword in creative_assessment.lower():
                     creativity_score += 0.05  # Increase score for each creative keyword found
-            
+
             # Cap score at 1.0
             creativity_score = min(creativity_score, 1.0)
-            
+
+            # Optional caption generation
+            caption = None
+            if hasattr(self.client.generate, "caption"):
+                try:
+                    caption_response = self.client.generate.caption(video_id=video_id)
+                    if hasattr(caption_response, "caption"):
+                        caption = caption_response.caption
+                    elif hasattr(caption_response, "data"):
+                        caption = caption_response.data
+                except Exception as e:
+                    logger.warning(f"Error generating caption: {str(e)}")
+
+            # Optional storyboard generation
+            storyboard = []
+            if hasattr(self.client.generate, "storyboard"):
+                try:
+                    storyboard_response = self.client.generate.storyboard(video_id=video_id)
+                    if hasattr(storyboard_response, "frames"):
+                        for frame in storyboard_response.frames:
+                            if hasattr(frame, "url"):
+                                storyboard.append(frame.url)
+                            else:
+                                storyboard.append(frame)
+                except Exception as e:
+                    logger.warning(f"Error generating storyboard: {str(e)}")
+
             # Update the confidence scores
             return {
                 "summary": summary,
@@ -182,7 +208,9 @@ class VideoAnalyzer:
                 "creative_assessment": creative_assessment,
                 "scenes": [summary],
                 "conversations": highlights[:2] if highlights else ["Conversation about milk"],
-                "creativity_score": creativity_score
+                "creativity_score": creativity_score,
+                "caption": caption,
+                "storyboard": storyboard
             }
             
         except Exception as e:

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -68,6 +68,12 @@ def process_video_post(video_path, post_data, analyzer, validator, classifier, t
         
         # Step 2: Analyze video with Twelve Labs
         analysis_results = analyzer.upload_and_analyze_video(video_path)
+
+        caption = None
+        storyboard = None
+        if analysis_results and "analysis_results" in analysis_results:
+            caption = analysis_results["analysis_results"].get("caption")
+            storyboard = analysis_results["analysis_results"].get("storyboard")
         
         # Ensure validator has access to analyzer for API calls
         validator.analyzer = analyzer
@@ -103,7 +109,9 @@ def process_video_post(video_path, post_data, analyzer, validator, classifier, t
             "mob_assignment": mob_assignment,
             "similar_videos": similar_videos,
             "location": location,
-            "processing_time": processing_time
+            "processing_time": processing_time,
+            "caption": caption,
+            "storyboard": storyboard
         }
         
     except Exception as e:

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -134,12 +134,19 @@ with tab1:
                                 st.write(f"- {nearby_mob['name']} ({nearby_mob['video_count']} videos in {nearby_mob['location']})")
                     
                      # Display API responses
-                    if "api_responses" in results["validation"]:
+                    if ("api_responses" in results["validation"]) or results.get("caption") or results.get("storyboard"):
                         with st.expander("Twelve Labs API Analysis"):
-                            st.subheader("Milk Detection")
-                            st.write(results["validation"]["api_responses"]["milk_question"])
-                            st.subheader("Creativity Assessment")
-                            st.write(results["validation"]["api_responses"]["creativity_question"])                    
+                            if "api_responses" in results["validation"]:
+                                st.subheader("Milk Detection")
+                                st.write(results["validation"]["api_responses"]["milk_question"])
+                                st.subheader("Creativity Assessment")
+                                st.write(results["validation"]["api_responses"]["creativity_question"])
+                            if results.get("caption"):
+                                st.subheader("AI Caption")
+                                st.write(results["caption"])
+                            if results.get("storyboard"):
+                                st.subheader("Storyboard")
+                                st.image(results["storyboard"])
                     # Display analysis details in an expander
                     with st.expander("View Technical Details"):
                         st.json(results["validation"])
@@ -160,7 +167,22 @@ with tab1:
                     st.error("❌ Video validation failed")
                     st.write(results["validation"]["message"])
                     st.write("Please ensure your video shows someone drinking milk creatively!")
-                    
+
+                    # Display AI results even on failure
+                    if ("api_responses" in results["validation"]) or results.get("caption") or results.get("storyboard"):
+                        with st.expander("Twelve Labs API Analysis"):
+                            if "api_responses" in results["validation"]:
+                                st.subheader("Milk Detection")
+                                st.write(results["validation"]["api_responses"]["milk_question"])
+                                st.subheader("Creativity Assessment")
+                                st.write(results["validation"]["api_responses"]["creativity_question"])
+                            if results.get("caption"):
+                                st.subheader("AI Caption")
+                                st.write(results["caption"])
+                            if results.get("storyboard"):
+                                st.subheader("Storyboard")
+                                st.image(results["storyboard"])
+
                     # Display analysis details in an expander
                     with st.expander("View Validation Details"):
                         st.json(results["validation"])


### PR DESCRIPTION
## Summary
- extend `VideoAnalyzer._generate_summary` to call optional caption and storyboard APIs
- propagate caption and storyboard fields through `process_video_post`
- display caption and storyboard in the Streamlit app
- document caption and storyboard usage in README

## Testing
- `python -m py_compile backend/analyzer.py backend/utils.py frontend/app.py`