### PR TITLE
Fix None value for creativity score

### DIFF
--- a/backend/classifier.py
+++ b/backend/classifier.py
@@ -149,7 +149,11 @@ class MilkMobClassifier:
         try:
             c = conn.cursor()
             order = "creativity_score DESC" if sort_by_creativity else "match_score DESC"
-            query = f"SELECT video_id, title, description, thumbnail_path, video_path, location, match_score, creativity_score FROM videos WHERE mob_id=? ORDER BY {order} LIMIT ?"
+            query = (
+                "SELECT video_id, title, description, thumbnail_path, "
+                "video_path, location, match_score, creativity_score "
+                "FROM videos WHERE mob_id=? ORDER BY " + order + " LIMIT ?"
+            )
             c.execute(query, (mob_id, limit))
             rows = c.fetchall()
             return [
@@ -160,8 +164,9 @@ class MilkMobClassifier:
                     "thumbnail_path": r[3],
                     "video_path": r[4],
                     "location": r[5],
-                    "match_score": r[6],
-                    "creativity_score": r[7],
+                    # Default to 0.0 if scores are NULL
+                    "match_score": r[6] if r[6] is not None else 0.0,
+                    "creativity_score": r[7] if r[7] is not None else 0.0,
                 }
                 for r in rows
             ]

--- a/frontend/explore_tab.py
+++ b/frontend/explore_tab.py
@@ -39,10 +39,11 @@ def render_video_card(video, key_prefix):
             st.markdown(f"📍 {video['location']}")
         
         # Display match score
-        score = video.get('match_score', 0.5)
+        score = video.get('match_score', 0.5) or 0.0
         st.progress(score, text=f"Match: {score:.0%}")
         if 'creativity_score' in video:
-            cscore = video.get('creativity_score', 0.0)
+            cscore = video.get('creativity_score')
+            cscore = cscore if cscore is not None else 0.0
             st.progress(cscore, text=f"Creativity: {cscore:.0%}")
         
         # Video player button


### PR DESCRIPTION
## Summary
- avoid None from DB when retrieving creativity_score
- handle None creativity scores in the frontend

## Testing
- `python -m py_compile frontend/explore_tab.py backend/classifier.py`