### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/backend/validator.py
+++ b/backend/validator.py
@@ -46,7 +46,7 @@ class CampaignValidator:
             "dance", "jump", "flip", "trick", "stunt"
         ]
 
-    def _analyze_campaign_prompt(self, analysis: dict, metadata: dict | None):
+    def _analyze_campaign_prompt(self, analysis: dict, metadata: Optional[Dict[str, Any]] = None):
         """Use OpenAI with a detailed campaign prompt to analyze the video."""
         if not self._openai_client:
             return None


### PR DESCRIPTION
## Summary
- support older Python versions by avoiding the 3.10 union operator

## Testing
- `python -m py_compile backend/*.py frontend/*.py`
- `pip install -r requirements.txt`